### PR TITLE
Add k8s patroni healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Please see the **[contributing](CONTRIBUTING.md)** and **[code of conduct](CODE_
 | k8s-kubectl-run | TaskSet | [runbook.robot](./codebundles/k8s-kubectl-run/runbook.robot) |      This codebundle runs an arbitrary kubectl command and writes the stdout to a report. |
 | k8s-kubectl-sanitycheck | TaskSet | [runbook.robot](./codebundles/k8s-kubectl-sanitycheck/runbook.robot) |      Used for troubleshooting the shellservice-based kubectl service |
 | k8s-kubectl-top | SLI | [sli.robot](./codebundles/k8s-kubectl-top/sli.robot) |      Retreieve aggregate data via kubectl top command. |
+| k8s-patroni-healthcheck | SLI | [sli.robot](./codebundles/k8s-patroni-healthcheck/sli.robot) |      Uses kubectl (or equivalent) to query the state of a patroni cluster and determine if it's healthy. |
 | k8s-triage-deploymentreplicas | TaskSet | [runbook.robot](./codebundles/k8s-triage-deploymentreplicas/runbook.robot) |      Triages issues related to a deployment's replicas. |
 | k8s-triage-patroni | TaskSet | [runbook.robot](./codebundles/k8s-triage-patroni/runbook.robot) |      Taskset to triage issues related to patroni. |
 | k8s-triage-statefulset | TaskSet | [runbook.robot](./codebundles/k8s-triage-statefulset/runbook.robot) |      A taskset for troubleshooting issues for StatefulSets and their related resources. |

--- a/codebundles/k8s-patroni-healthcheck/sli.robot
+++ b/codebundles/k8s-patroni-healthcheck/sli.robot
@@ -1,0 +1,65 @@
+*** Settings ***
+Metadata          Author    Jonathan Funk
+Documentation     Uses kubectl (or equivalent) to query the state of a patroni cluster and determine if it's healthy.
+Force Tags        K8s    Kubernetes    Kube    K8    Patroni    Health
+Suite Setup       Suite Initialization
+Library           BuiltIn
+Library           RW.Core
+Library           RW.Utils
+Library           RW.K8s
+Library           RW.Patroni
+Library           RW.platform
+Library           OperatingSystem
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${PATRONI_RESOURCE_NAME}=    RW.Core.Import User Variable    PATRONI_RESOURCE_NAME
+    ...    type=string
+    ...    description=Determine which object is queried for health information.
+    ...    pattern=\w*
+    ...    example=statefulset/my-patroni
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the Kubernetes namespace to scope actions and searching to.
+    ...    pattern=\w*
+    ...    example=my-namespace
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=my-main-cluster
+    ${DISTRIBUTION}=    RW.Core.Import User Variable    DISTRIBUTION
+    ...    type=string
+    ...    description=Which distribution of Kubernetes to use for operations, such as: Kubernetes, OpenShift, etc.
+    ...    pattern=\w*
+    ...    enum=[Kubernetes,GKE,OpenShift]
+    ...    example=Kubernetes
+    ${LAG_TOLERANCE}=    RW.Core.Import User Variable    LAG_TOLERANCE
+    ...    type=string
+    ...    description=Determines the tolerance of data drift between the leader and replicas. Value represents MB akin to the output of 'patronictl list'.
+    ...    pattern=^\d+$
+    ...    example=1
+    ...    default=1
+    ${binary_name}=    RW.K8s.Get Binary Name    ${DISTRIBUTION}
+    Set Suite Variable    ${binary_name}    ${binary_name}
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+
+*** Tasks ***
+Determine Patroni Health
+    ${stdout}=    RW.K8s.Shell
+    ...    cmd=${binary_name} exec ${PATRONI_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- patronictl list -e -f yaml
+    ...    target_service=${kubectl}
+    ...    kubeconfig=${kubeconfig}
+    ${state_yaml}=    RW.Utils.Yaml To Dict    yaml_str=${stdout}
+    ${is_healthy}=    RW.Patroni.Patroni State Healthy    state=${state_yaml}    lag_tolerance=${LAG_TOLERANCE}
+    ${metric}=    Evaluate    1 if ${is_healthy} else 0
+    RW.Core.Push Metric    ${metric}

--- a/libraries/RW/Patroni/__init__.py
+++ b/libraries/RW/Patroni/__init__.py
@@ -1,0 +1,1 @@
+from .patroni import Patroni

--- a/libraries/RW/Patroni/patroni.py
+++ b/libraries/RW/Patroni/patroni.py
@@ -1,0 +1,36 @@
+"""
+Patroni keyword library
+
+Scope: Global
+"""
+import time
+from dataclasses import dataclass
+from typing import Union, Optional
+
+
+class Patroni:
+    """
+    Patroni keyword library
+    """
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    def patroni_state_healthy(self, state: list, lag_tolerance: int=1) -> bool:
+        healthy: bool = True
+        last_timeline = None
+        found_leader: bool = False
+        for member in state:
+            # first determine if all replicas are on the same timeline
+            if last_timeline is not None and last_timeline != member["TL"]:
+                healthy = False
+            last_timeline = member["TL"]
+            # check running
+            # TODO: revisit state tolerance and determine acceptable rollover states
+            if member["State"] != "running":
+                healthy = False
+            # we should have a leader
+            if member["Role"] == "Leader":
+                found_leader = True
+            if "Lag in MB" in member and int(member["Lag in MB"]) > lag_tolerance:
+                healthy = False
+        return (healthy and found_leader)


### PR DESCRIPTION
- adds codebundle for testing the healthcheck of patroni when the patroni REST API is not publicly available
- Uses kubectl to fetch the cluster state