### PR TITLE
Add Kubernetes Postgres Query Metric Codebundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Please see the **[contributing](CONTRIBUTING.md)** and **[code of conduct](CODE_
 | k8s-kubectl-sanitycheck | TaskSet | [runbook.robot](./codebundles/k8s-kubectl-sanitycheck/runbook.robot) |      Used for troubleshooting the shellservice-based kubectl service |
 | k8s-kubectl-top | SLI | [sli.robot](./codebundles/k8s-kubectl-top/sli.robot) |      Retreieve aggregate data via kubectl top command. |
 | k8s-patroni-healthcheck | SLI | [sli.robot](./codebundles/k8s-patroni-healthcheck/sli.robot) |      Uses kubectl (or equivalent) to query the state of a patroni cluster and determine if it's healthy. |
+| k8s-postgres-querymetric | SLI | [sli.robot](./codebundles/k8s-postgres-querymetric/sli.robot) |      Runs a postgres SQL query and pushes the returned query result as an SLI metric. |
 | k8s-triage-deploymentreplicas | TaskSet | [runbook.robot](./codebundles/k8s-triage-deploymentreplicas/runbook.robot) |      Triages issues related to a deployment's replicas. |
 | k8s-triage-patroni | TaskSet | [runbook.robot](./codebundles/k8s-triage-patroni/runbook.robot) |      Taskset to triage issues related to patroni. |
 | k8s-triage-statefulset | TaskSet | [runbook.robot](./codebundles/k8s-triage-statefulset/runbook.robot) |      A taskset for troubleshooting issues for StatefulSets and their related resources. |

--- a/codebundles/k8s-postgres-querymetric/README.md
+++ b/codebundles/k8s-postgres-querymetric/README.md
@@ -1,0 +1,19 @@
+# Kubernetes Postgres Query Metric
+
+## SLI
+This codebundle uses a Kubernetes workload to run a postgres SQL query and pushes the query result as an SLI metric.
+During execution, the SQL query should be passed to a Kubernetes workload that has access to the `psql` binary.
+The workload will run the query and return the result from stdout.
+
+## Use Cases
+- When you have a postgres deployment or equivalent (eg: patroni) deployment in your kubernetes cluster and would like to use a query result as a metric without publicly exposing the database.
+- If you want to periodically check and measure an attribute of your database, such as slow queries, memory usage, index efficiency, etc.
+
+## Requirements
+- A kubeconfig with adequate access permissions to the execution workload running the query.
+- A postgres compatible query which returns a single result row. If you're getting multiple rows consider aggregating them via COUNT, MAX, SUM, GROUP BY, etc.
+- A kubernetes workload with `psql` binary as part of its image that can access the database within the constraints of its network. You can use the same workload as the one running the database.
+- The `hostname`, `user`, `password`, `database name` credentials, where the user has adequate permissions to perform the query on the desired table.
+
+## TODO
+- [ ] Add additional documentation

--- a/codebundles/k8s-postgres-querymetric/sli.robot
+++ b/codebundles/k8s-postgres-querymetric/sli.robot
@@ -1,0 +1,82 @@
+*** Settings ***
+Metadata          Author    Jonathan Funk
+Documentation     Runs a postgres SQL query and pushes the returned query result as an SLI metric.
+...               During execution, the SQL query should be passed to a Kubernetes workload that has access to the psql binary.
+...               The workload will run the query and return the result from stdout.
+Force Tags        K8s    Kubernetes    Postgres    SQL    database    psql
+Suite Setup       Suite Initialization
+Library           RW.Core
+Library           RW.K8s
+Library           RW.Postgres
+Library           RW.Utils
+Library           RW.platform
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${psql-password}=    RW.Core.Import Secret    psql-password
+    ...    type=string
+    ...    description=The password used when querying the postgres database.
+    ...    pattern=\w*
+    ...    example=mysupersecretpassword
+    ${psql-database}=    RW.Core.Import Secret    psql-database
+    ...    type=string
+    ...    description=The database name used to determine what database is being queried.
+    ...    pattern=\w*
+    ...    example=mydb
+    ${psql-username}=    RW.Core.Import Secret    psql-username
+    ...    type=string
+    ...    description=The username used when querying the postgres database.
+    ...    pattern=\w*
+    ...    example=myuser
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${WORKLOAD_NAME}=    RW.Core.Import User Variable    WORKLOAD_NAME
+    ...    type=string
+    ...    description=Which workload to run the postgres query from. This workload should have the psql binary in its image and be able to access the database workload within its network constraints.
+    ...    pattern=\w*
+    ...    example=deployment/myapp
+    ${QUERY}=    RW.Core.Import User Variable    QUERY
+    ...    type=string
+    ...    description=The postgres query to run on the workload. Ensure this query returns a single row with a numerical value.
+    ...    pattern=\w*
+    ...    default=SELECT 1;
+    ...    example=SELECT COUNT(id) FROM my_table;
+    ${HOSTNAME}=    RW.Core.Import User Variable    HOSTNAME
+    ...    type=string
+    ...    description=The hostname specified in the psql connection string. Use localhost if the execution workload is the database workload.
+    ...    pattern=\w*
+    ...    default=localhost
+    ...    example=localhost
+    ${DISTRIBUTION}=    RW.Core.Import User Variable    DISTRIBUTION
+    ...    type=string
+    ...    description=Which distribution of Kubernetes to use for operations, such as: Kubernetes, OpenShift, etc.
+    ...    pattern=\w*
+    ...    enum=[Kubernetes,GKE,OpenShift]
+    ...    example=Kubernetes
+    ${binary_name}=    RW.K8s.Get Binary Name    ${DISTRIBUTION}
+    Set Suite Variable    ${binary_name}    ${binary_name}
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+
+*** Tasks ***
+Run Postgres Query And Return Result As Metric
+    ${templated_query}=    RW.Postgres.Template Command
+    ...    query=${QUERY}
+    ...    hostname=${HOSTNAME}
+    ...    database=${psql-database}
+    ...    username=${psql-username}
+    ...    password=${psql-password}
+    ${shell_secrets}=    RW.Utils.Secrets List    ${psql-database}    ${psql-username}    ${psql-password}
+    ${rsp}=    RW.K8s.Shell
+    ...    cmd=${binary_name} exec ${WORKLOAD_NAME} -- bash -c "${templated_query}"
+    ...    target_service=${kubectl}
+    ...    kubeconfig=${KUBECONFIG}
+    ...    shell_secrets=${shell_secrets}
+    ${metric}=    RW.Utils.To Float    ${rsp}
+    RW.Core.Push Metric    ${metric}

--- a/libraries/RW/K8s/robot_tests/exec.robot
+++ b/libraries/RW/K8s/robot_tests/exec.robot
@@ -1,0 +1,40 @@
+*** Settings ***
+Library           RW.K8s
+Library           RW.Postgres
+Library           RW.Utils
+Library           RW.platform
+Library           RW.Core
+Library           OperatingSystem
+Suite Setup       Suite Initialization
+
+*** Tasks ***
+Get Postgres Query Result
+    ${templated_query}=    RW.Postgres.Template Command
+    ...    query=${K8S_DB_QUERY}
+    ...    hostname=localhost
+    ...    database=${TEST_DB}
+    ...    username=${TEST_USER}
+    ...    password=${TEST_DB_PASSWORD}
+    ${shell_secrets}=    RW.Utils.Secrets List    ${TEST_DB}    ${TEST_USER}    ${TEST_DB_PASSWORD}
+    ${rsp}=    RW.K8s.Shell
+    ...    cmd=kubectl exec ${TEST_DB_WORKLOAD} -- bash -c "${templated_query}"
+    ...    target_service=${kubectl}
+    ...    kubeconfig=${KUBECONFIG}
+    ...    shell_secrets=${shell_secrets}
+
+*** Keywords ***
+Suite Initialization
+    RW.Core.Import Service    kubectl
+    Set Suite Variable    ${kubectl}    ${kubectl}
+    Set Suite Variable    ${KUBECONFIG_PATH}    %{KUBECONFIG_PATH}
+    Set Suite Variable    ${TEST_DB_WORKLOAD}    %{TEST_DB_WORKLOAD}
+    Set Suite Variable    ${K8S_DB_QUERY}    %{K8S_DB_QUERY}
+    ${KUBECONFIG}=    Get File    ${KUBECONFIG_PATH}
+    ${KUBECONFIG}=    Evaluate    RW.platform.Secret("kubeconfig", """${KUBECONFIG}""")
+    ${TEST_DB}=    Evaluate    RW.platform.Secret("test_db", """%{TEST_DB}""")
+    ${TEST_USER}=    Evaluate    RW.platform.Secret("test_user", """%{TEST_DB_USER}""")
+    ${TEST_DB_PASSWORD}=    Evaluate    RW.platform.Secret("test_pass", """%{TEST_DB_PASSWORD}""")
+    Set Suite Variable    ${KUBECONFIG}    ${KUBECONFIG}
+    Set Suite Variable    ${TEST_DB}    ${TEST_DB}
+    Set Suite Variable    ${TEST_USER}    ${TEST_USER}
+    Set Suite Variable    ${TEST_DB_PASSWORD}    ${TEST_DB_PASSWORD}

--- a/libraries/RW/Postgres/__init__.py
+++ b/libraries/RW/Postgres/__init__.py
@@ -1,0 +1,1 @@
+from .postgres import Postgres

--- a/libraries/RW/Postgres/postgres.py
+++ b/libraries/RW/Postgres/postgres.py
@@ -1,0 +1,29 @@
+"""
+Postgres keyword library
+
+Scope: Global
+"""
+import time
+from dataclasses import dataclass
+from typing import Union, Optional
+from RW import platform
+
+
+class Postgres:
+    """
+    Postgres keyword library
+    """
+
+    ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+    def template_command(
+        self,
+        query: str,
+        database: platform.Secret,
+        username: platform.Secret,
+        password: platform.Secret,
+        hostname: str="hostname",
+        default_flags: str="-qAt"
+    ) -> str:
+        command = f"PGPASSWORD='${password.key}' psql {default_flags} -U ${username.key} -d ${database.key} -h {hostname} -c '{query}'"
+        return command

--- a/libraries/RW/Utils/utils.py
+++ b/libraries/RW/Utils/utils.py
@@ -145,6 +145,19 @@ def to_int(v) -> Union[int, list[int]]:
             f"Expected a scalar or list value (actual value: {v})"
         )
 
+def to_float(v) -> Union[float, list[float]]:
+    """
+    Convert the input parameter, which may be a scalar or a list, into
+    float value(s).
+    """
+    if is_scalar(v):
+        return float(v)
+    elif is_list(v):
+        return [float(x) for x in v]
+    else:
+        raise ValueError(
+            f"Expected a scalar or list value (actual value: {v})"
+        )
 
 def prettify(data) -> str:
     return pprint.pformat(data, indent=1, width=80)

--- a/libraries/RW/Utils/utils.py
+++ b/libraries/RW/Utils/utils.py
@@ -303,3 +303,10 @@ def templated_string_list(template_string : str, values : list, key_name="item")
         format_map = {key_name:value}
         str_list.append(template_string.format(**format_map))
     return str_list
+
+def secrets_list(*args) -> [platform.Secret]:
+    secrets_list: [platform.Secrets] = []
+    for arg in args:
+        if isinstance(arg, platform.Secret):
+            secrets_list.append(arg)
+    return secrets_list


### PR DESCRIPTION
- Updates the `RW.K8s.Shell` keyword to support an auxiliary and optional list of secrets which will be substituted into the shell string on the location service. values are substituted by using `$my-secret-key` as the identifier in the string.
- Adds a codebundle that can run a postgres query on a k8s workload and return the query result as an SLI metric.
- Adds util functions for converting to float, and constructing a list of platform secrets