### PR TITLE
Move actions to push to main for index update

### DIFF
--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -8,6 +8,11 @@ on:
       - "readme_header.md"
       - ".github/scripts/index.sh"
       - ".github/workflows/generate-index.yml"
+
+permissions:
+  contents: "write"
+  id-token: "write"
+
 jobs:
   update-readme:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -2,7 +2,9 @@
 name: Generate readme file with codebundle index
 on:
   workflow_dispatch:
-  pull_request:
+  push:
+    branches:
+      - main
     paths: 
       - "codebundles/**"
       - "readme_header.md"

--- a/.github/workflows/generate-index.yml
+++ b/.github/workflows/generate-index.yml
@@ -11,10 +11,6 @@ on:
       - ".github/scripts/index.sh"
       - ".github/workflows/generate-index.yml"
 
-permissions:
-  contents: "write"
-  id-token: "write"
-
 jobs:
   update-readme:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Documentation for each codebundle is maintained in the README.md alongside the r
 | rocketchat-plain-notification | TaskSet | [runbook.robot](./codebundles/rocketchat-plain-notification/runbook.robot) |      Send a message to an RocketChat channel. |
 | sysdig-monitor-metric | SLI | [sli.robot](./codebundles/sysdig-monitor-metric/sli.robot) |      Queries the Sysdig data API to fetch metric data. |
 | sysdig-monitor-promqlmetric | SLI | [sli.robot](./codebundles/sysdig-monitor-promqlmetric/sli.robot) |      Queries the Sysdig data API with a PromQL query to fetch metric data. |
+| twitter-query-tweets | TaskSet | [runbook.robot](./codebundles/twitter-query-tweets/runbook.robot) |      Queries Twitter to fetch tweets within a specified time range for a specific user handle add them to a report. |
+| twitter-query-tweets | SLI | [sli.robot](./codebundles/twitter-query-tweets/sli.robot) |      Queries Twitter to count amount of tweets within a specified time range for a specific user handle. |
 | uptimecom-component-ok | SLI | [sli.robot](./codebundles/uptimecom-component-ok/sli.robot) |      Check the status of an Uptime.com component for a given site. |
 | vault-ok | SLI | [sli.robot](./codebundles/vault-ok/sli.robot) |      Check the health of a Vault server. |
 | web-triage | TaskSet | [runbook.robot](./codebundles/web-triage/runbook.robot) |      Troubleshoot and triage a URL to inspect it for common issues such as an expired certification, missing DNS records, etc. |


### PR DESCRIPTION
This workflow change is intended to move the index generation to a push to main activity on the repo, rather than the PR. This should resolved forked PR issues with updating the index by keeping the activity focused on the main branch of the source repo. 

Aims to resolve #21 