### PR TITLE
Add SLI and Runbook for K8s based Cortex Metrics Ingester Health

### DIFF
--- a/codebundles/k8s-cortexmetrics-ingestor-health/README.md
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/README.md
@@ -1,0 +1,18 @@
+# Kubernetes Cortex Metrics Ingester Health
+
+## SLI
+Periodically checks the state of the cortex metrics ingestors and returns a score of 1 (healthy) or 0 (unhealthy). This SLI performs the query by executing a `kubectl exec` into a Kubernetes resource, leveraging existing Kubernetes API authentication. For the ingesters to be considered healthy they must:
+
+- Be considered "ACTIVE" in the ingester ring as published by the http api endpoint `/ring`
+- Have as many "ACTIVE" ingester ring members as specified in the SLI configuration variable EXPECTED_RING_MEMBERS
+
+## TaskSet
+Queries the state of ingestors and returns the state of each along with the latest timestamp . This TaskSet performs the query by executing a `kubectl exec` into a Kubernetes resource, leveraging existing Kubernetes API authentication. 
+
+## Requirements
+- A kubeconfig with `get, list` access on cortex objects in the chosen namespace, along with the verb `create` on resource `pods/exec`
+- A chosen `namespace` and `context` to use from the kubeconfig
+- A cortex pod resource that has access to the `ring` api endpoint to exec into within the chosen `namespace` (often the distributor pods)
+
+## TODO
+- [ ] Add additional documentation

--- a/codebundles/k8s-cortexmetrics-ingestor-health/README.md
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/README.md
@@ -6,6 +6,8 @@ Periodically checks the state of the cortex metrics ingestors and returns a scor
 - Be considered "ACTIVE" in the ingester ring as published by the http api endpoint `/ring`
 - Have as many "ACTIVE" ingester ring members as specified in the SLI configuration variable EXPECTED_RING_MEMBERS
 
+The defaults will target a distributor pod which can locally reach http://127.0.0.1:8080/ring to obtain the status, but this can be overridden if another pod is used to query this endpoint within the cluster. 
+
 ## TaskSet
 Queries the state of ingestors and returns the state of each along with the latest timestamp . This TaskSet performs the query by executing a `kubectl exec` into a Kubernetes resource, leveraging existing Kubernetes API authentication. 
 

--- a/codebundles/k8s-cortexmetrics-ingestor-health/README.md
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/README.md
@@ -16,3 +16,4 @@ Queries the state of ingestors and returns the state of each along with the late
 
 ## TODO
 - [ ] Add additional documentation
+- [ ] Add additional taskset checks 

--- a/codebundles/k8s-cortexmetrics-ingestor-health/runbook.robot
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/runbook.robot
@@ -1,0 +1,71 @@
+*** Settings ***
+Documentation       Uses kubectl to query the state of a ingestor ring. Returns the json of injester id, status and timestamp.
+Metadata            Author    Shea Stewart
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.Utils
+Library             RW.K8s
+Library             RW.platform
+Library             OperatingSystem
+
+Suite Setup         Suite Initialization
+
+Force Tags          k8s    kubernetes    kube    k8    cortex    metrics    health
+
+
+*** Tasks ***
+Fetch Ingestor Ring Member List and Status
+    ${stdout}=    RW.K8s.Shell
+    ...    cmd=${binary_name} exec ${CORTEX_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- wget -O - --header 'Accept: application/json' http://127.0.0.1:8080/ring
+    ...    target_service=${kubectl}
+    ...    kubeconfig=${kubeconfig}
+
+    ${filter_active_ingesters}=    RW.Utils.Search Json
+    ...    data=${stdout}
+    ...    pattern=shards[*].[id, state, timestamp]
+
+    RW.Core.Add Pre To Report    ${filter_active_ingesters}
+
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${CORTEX_RESOURCE_NAME}=    RW.Core.Import User Variable    CORTEX_RESOURCE_NAME
+    ...    type=string
+    ...    description=Determine which Kubernetes object is queried for cortex ingester health information.
+    ...    pattern=\w*
+    ...    default=deployment/cortex-distributor
+    ...    example=deployment/cortex-distributor
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the Kubernetes namespace where cortex is deployed.
+    ...    pattern=\w*
+    ...    default=cortex
+    ...    example=cortex
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=my-main-cluster
+    ${DISTRIBUTION}=    RW.Core.Import User Variable    DISTRIBUTION
+    ...    type=string
+    ...    description=Which distribution of Kubernetes to use for operations, such as: Kubernetes, OpenShift, etc.
+    ...    pattern=\w*
+    ...    enum=[Kubernetes,GKE,OpenShift]
+    ...    example=Kubernetes
+    ${binary_name}=    RW.K8s.Get Binary Name    ${DISTRIBUTION}
+    Set Suite Variable    ${binary_name}    ${binary_name}
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+    Set Suite Variable    ${DISTRIBUTION}    ${DISTRIBUTION}
+    Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
+    Set Suite Variable    ${CORTEX_RESOURCE_NAME}    ${CORTEX_RESOURCE_NAME}

--- a/codebundles/k8s-cortexmetrics-ingestor-health/runbook.robot
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/runbook.robot
@@ -17,7 +17,7 @@ Force Tags          k8s    kubernetes    kube    k8    cortex    metrics    heal
 *** Tasks ***
 Fetch Ingestor Ring Member List and Status
     ${stdout}=    RW.K8s.Shell
-    ...    cmd=${binary_name} exec ${CORTEX_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- wget -O - --header 'Accept: application/json' http://127.0.0.1:8080/ring
+    ...    cmd=${binary_name} exec ${CORTEX_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- wget -O - --header 'Accept: application/json' ${CORTEX_INGESTER_RING_URL}
     ...    target_service=${kubectl}
     ...    kubeconfig=${kubeconfig}
 
@@ -46,6 +46,13 @@ Suite Initialization
     ...    pattern=\w*
     ...    default=deployment/cortex-distributor
     ...    example=deployment/cortex-distributor
+    ${CORTEX_INGESTER_RING_URL}=    RW.Core.Import User Variable
+    ...    CORTEX_INGESTER_RING_URL
+    ...    type=string
+    ...    description=Host to query that resolves the ingester ring endpoint. Typically http://127.0.0.1:8080/ring if querying from a distributor pod.
+    ...    pattern=\w*
+    ...    default='http://127.0.0.1:8080/ring'
+    ...    example='http://127.0.0.1:8080/ring'
     ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
     ...    type=string
     ...    description=The name of the Kubernetes namespace where cortex is deployed.
@@ -69,3 +76,4 @@ Suite Initialization
     Set Suite Variable    ${DISTRIBUTION}    ${DISTRIBUTION}
     Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
     Set Suite Variable    ${CORTEX_RESOURCE_NAME}    ${CORTEX_RESOURCE_NAME}
+    Set Suite Variable    ${CORTEX_INGESTER_RING_URL}    ${CORTEX_INGESTER_RING_URL}

--- a/codebundles/k8s-cortexmetrics-ingestor-health/sli.robot
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/sli.robot
@@ -17,7 +17,7 @@ Force Tags          k8s    kubernetes    kube    k8    cortex    metrics    heal
 *** Tasks ***
 Determine Cortex Ingester Ring Health
     ${stdout}=    RW.K8s.Shell
-    ...    cmd=${binary_name} exec ${CORTEX_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- wget -O - --header 'Accept: application/json' http://127.0.0.1:8080/ring
+    ...    cmd=${binary_name} exec ${CORTEX_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- wget -O - --header 'Accept: application/json' ${CORTEX_INGESTER_RING_URL}
     ...    target_service=${kubectl}
     ...    kubeconfig=${kubeconfig}
 
@@ -48,6 +48,13 @@ Suite Initialization
     ...    pattern=\w*
     ...    default=deployment/cortex-distributor
     ...    example=deployment/cortex-distributor
+    ${CORTEX_INGESTER_RING_URL}=    RW.Core.Import User Variable
+    ...    CORTEX_INGESTER_RING_URL
+    ...    type=string
+    ...    description=Host to query that resolves the ingester ring endpoint. Typically http://127.0.0.1:8080/ring if querying from a distributor pod.
+    ...    pattern=\w*
+    ...    default='http://127.0.0.1:8080/ring'
+    ...    example='http://127.0.0.1:8080/ring'
     ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
     ...    type=string
     ...    description=The name of the Kubernetes namespace where cortex is deployed.
@@ -78,3 +85,4 @@ Suite Initialization
     Set Suite Variable    ${DISTRIBUTION}    ${DISTRIBUTION}
     Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
     Set Suite Variable    ${CORTEX_RESOURCE_NAME}    ${CORTEX_RESOURCE_NAME}
+    Set Suite Variable    ${CORTEX_INGESTER_RING_URL}    ${CORTEX_INGESTER_RING_URL}

--- a/codebundles/k8s-cortexmetrics-ingestor-health/sli.robot
+++ b/codebundles/k8s-cortexmetrics-ingestor-health/sli.robot
@@ -1,0 +1,80 @@
+*** Settings ***
+Documentation       Uses kubectl to query the state of a ingestor ring and determine if it's healthy. Returns 1 if healthy, 0 if unhealthy.
+Metadata            Author    Shea Stewart
+
+Library             BuiltIn
+Library             RW.Core
+Library             RW.Utils
+Library             RW.K8s
+Library             RW.platform
+Library             OperatingSystem
+
+Suite Setup         Suite Initialization
+
+Force Tags          k8s    kubernetes    kube    k8    cortex    metrics    health
+
+
+*** Tasks ***
+Determine Cortex Ingester Ring Health
+    ${stdout}=    RW.K8s.Shell
+    ...    cmd=${binary_name} exec ${CORTEX_RESOURCE_NAME} -n ${NAMESPACE} --context ${CONTEXT} -it -- wget -O - --header 'Accept: application/json' http://127.0.0.1:8080/ring
+    ...    target_service=${kubectl}
+    ...    kubeconfig=${kubeconfig}
+
+    ${filter_active_ingesters}=    RW.Utils.Search Json
+    ...    data=${stdout}
+    ...    pattern=shards[?state == 'ACTIVE'].[id, state, timestamp]
+
+    ${total_active_ingesters}=    Get Length    ${filter_active_ingesters}
+    ${metric}=    Evaluate    1 if ${total_active_ingesters}==${EXPECTED_RING_MEMBERS} else 0
+    RW.Core.Push Metric    ${metric}
+
+
+*** Keywords ***
+Suite Initialization
+    ${kubeconfig}=    RW.Core.Import Secret
+    ...    kubeconfig
+    ...    type=string
+    ...    description=The kubernetes kubeconfig yaml containing connection configuration used to connect to cluster(s).
+    ...    pattern=\w*
+    ...    example=For examples, start here https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+    ${kubectl}=    RW.Core.Import Service    kubectl
+    ...    description=The location service used to interpret shell commands.
+    ...    default=kubectl-service.shared
+    ...    example=kubectl-service.shared
+    ${CORTEX_RESOURCE_NAME}=    RW.Core.Import User Variable    CORTEX_RESOURCE_NAME
+    ...    type=string
+    ...    description=Determine which Kubernetes object is queried for cortex ingester health information.
+    ...    pattern=\w*
+    ...    default=deployment/cortex-distributor
+    ...    example=deployment/cortex-distributor
+    ${NAMESPACE}=    RW.Core.Import User Variable    NAMESPACE
+    ...    type=string
+    ...    description=The name of the Kubernetes namespace where cortex is deployed.
+    ...    pattern=\w*
+    ...    default=cortex
+    ...    example=cortex
+    ${CONTEXT}=    RW.Core.Import User Variable    CONTEXT
+    ...    type=string
+    ...    description=Which Kubernetes context to operate within.
+    ...    pattern=\w*
+    ...    example=my-main-cluster
+    ${DISTRIBUTION}=    RW.Core.Import User Variable    DISTRIBUTION
+    ...    type=string
+    ...    description=Which distribution of Kubernetes to use for operations, such as: Kubernetes, OpenShift, etc.
+    ...    pattern=\w*
+    ...    enum=[Kubernetes,GKE,OpenShift]
+    ...    example=Kubernetes
+    ${EXPECTED_RING_MEMBERS}=    RW.Core.Import User Variable    EXPECTED_RING_MEMBERS
+    ...    type=string
+    ...    description=Total number of ring members that should be ACTIVE.
+    ...    pattern=^\d+$
+    ...    example=3
+    ...    default=3
+    ${binary_name}=    RW.K8s.Get Binary Name    ${DISTRIBUTION}
+    Set Suite Variable    ${binary_name}    ${binary_name}
+    Set Suite Variable    ${kubeconfig}    ${kubeconfig}
+    Set Suite Variable    ${EXPECTED_RING_MEMBERS}    ${EXPECTED_RING_MEMBERS}
+    Set Suite Variable    ${DISTRIBUTION}    ${DISTRIBUTION}
+    Set Suite Variable    ${NAMESPACE}    ${NAMESPACE}
+    Set Suite Variable    ${CORTEX_RESOURCE_NAME}    ${CORTEX_RESOURCE_NAME}

--- a/libraries/RW/Utils/RWUtils.py
+++ b/libraries/RW/Utils/RWUtils.py
@@ -15,6 +15,7 @@ from RW import platform
 from RW.Utils import utils
 
 
+
 class RWUtils:
     #TODO: merge with utils
     """Utility keyword library for useful bits and bobs."""
@@ -53,6 +54,25 @@ class RWUtils:
         Convert from Python dictionary to JSON string.
         """
         return utils.to_json(*args, **kwargs)
+
+    def string_to_json(self, *args, **kwargs) -> str:
+        """Convert a string to a JSON serializable object and return it.
+
+        :param str: JSON string
+        :return: JSON serializable object of the string
+
+        """
+        return utils.string_to_json(*args, **kwargs) 
+
+    def search_json(self, *args, **kwargs) -> dict:
+        """Search JSON dictionary using jmespath.
+
+        :data dict: JSON dictionary to search through. 
+        :pattern str: Pattern to search. See https://jmespath.org/? to test search strings.
+        :return: JSON Dict of search results. 
+
+        """
+        return utils.search_json(*args, **kwargs) 
 
     def from_json(self, *args, **kwargs) -> object:
         """
@@ -141,3 +161,33 @@ class RWUtils:
         :return str
         """
         return utils.encode_url(hostname, params, verbose)
+    
+    # def get_values_from_json(self, doc: JSONType, expr: str) -> list:
+    #     """Get all values from a JSON serializable object that match the given expression.
+
+    #     :param doc: JSON serializable object or string
+    #     :param expr: JSONPath expression
+    #     :return: list of values that match
+
+    #     Short Robot Framework Example:
+
+    #     .. code::
+
+    #         *** Task ***
+    #         Get all the names for all people
+    #             &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
+    #             @{names}=     Get values from JSON     ${people}   $.People[*].Name
+        
+    #     Code written by and found on https://github.com/robocorp/rpaframework 
+    #     """  
+    #     self.logger.info("Get values from JSON with expression: %r", expr)
+    #     return [match.value for match in parse(expr).find(doc)]
+
+    def get_values_from_json(self, *args, **kwargs) -> list:
+        """Convert a string to a JSON serializable object and return it.
+
+        :param str: JSON string
+        :return: JSON serializable object of the string
+
+        """
+        return utils.get_values_from_json(*args, **kwargs) 

--- a/libraries/RW/Utils/RWUtils.py
+++ b/libraries/RW/Utils/RWUtils.py
@@ -162,32 +162,3 @@ class RWUtils:
         """
         return utils.encode_url(hostname, params, verbose)
     
-    # def get_values_from_json(self, doc: JSONType, expr: str) -> list:
-    #     """Get all values from a JSON serializable object that match the given expression.
-
-    #     :param doc: JSON serializable object or string
-    #     :param expr: JSONPath expression
-    #     :return: list of values that match
-
-    #     Short Robot Framework Example:
-
-    #     .. code::
-
-    #         *** Task ***
-    #         Get all the names for all people
-    #             &{people}=    Convert string to JSON   {"People": [{"Name": "Mark"}, {"Name": "Jane"}]}
-    #             @{names}=     Get values from JSON     ${people}   $.People[*].Name
-        
-    #     Code written by and found on https://github.com/robocorp/rpaframework 
-    #     """  
-    #     self.logger.info("Get values from JSON with expression: %r", expr)
-    #     return [match.value for match in parse(expr).find(doc)]
-
-    def get_values_from_json(self, *args, **kwargs) -> list:
-        """Convert a string to a JSON serializable object and return it.
-
-        :param str: JSON string
-        :return: JSON serializable object of the string
-
-        """
-        return utils.get_values_from_json(*args, **kwargs) 

--- a/libraries/RW/Utils/utils.py
+++ b/libraries/RW/Utils/utils.py
@@ -5,6 +5,7 @@ Robot Keywords via RW.Utils.
 """
 from typing import Iterable, Any, Union, Optional
 import os, pprint, functools, time, json, datetime, yaml, logging, re, xml.dom.minidom, urllib.parse
+import jmespath
 from enum import Enum
 from benedict import benedict
 from robot.libraries.BuiltIn import BuiltIn
@@ -16,6 +17,7 @@ logger = logging.getLogger(__name__)
 #TODO: refresh funcs using outdated dependencies
 #TODO: port RWUtils over to here / merge / deduplicate
 #TODO: add control structure keywords
+
 
 class Status(Enum):
     NOT_OK = 0
@@ -97,6 +99,14 @@ def from_json(json_str, strict: bool = False) -> object:
 
 def to_json(data: object) -> str:
     return json.dumps(data)
+
+def string_to_json(data: str)-> str:
+    return json.loads(data)
+
+def search_json(data: dict, pattern: str)-> dict:
+    # BuiltIn().run_keyword('Log', f'{pattern} {data}')
+    result = jmespath.search(pattern, data) 
+    return result
 
 
 def from_yaml(yaml_str) -> object:

--- a/libraries/RW/Utils/utils.py
+++ b/libraries/RW/Utils/utils.py
@@ -104,7 +104,6 @@ def string_to_json(data: str)-> str:
     return json.loads(data)
 
 def search_json(data: dict, pattern: str)-> dict:
-    # BuiltIn().run_keyword('Log', f'{pattern} {data}')
     result = jmespath.search(pattern, data) 
     return result
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ sdcclient>=0.16
 snscrape>=0.4.3.20220106
 jq>=1.3.0
 pandas>=1.5.2
+jmespath>=1.0.1


### PR DESCRIPTION
Please see the docs for further info, but uses kubectl to exec into a pod and query the ring endpoint for the health status of the ingestors. Includes an SLI and Taskset along with very basic json keywords for search (with jmespath). I thought jmespath might be a better option than jsonpath_ng as it has useful online resources such as https://jmespath.org/? and feels fairly functiona & readable. 