### PR TITLE
remove labels from push metric on postgres

### DIFF
--- a/codebundles/k8s-postgres-query/sli.robot
+++ b/codebundles/k8s-postgres-query/sli.robot
@@ -35,7 +35,9 @@ Run Postgres Query And Return Result As Metric
     ...    shell_secrets=${shell_secrets}
     ${results}=    RW.Postgres.Parse Metric And Time    psql_result=${rsp}
     ${metric}=    RW.Utils.To Float    ${results['metric']}
-    RW.Core.Push Metric    ${metric}    sub_name=with_labels    time=${results['time']}
+    RW.Core.Push Metric    ${metric}
+    # Add this back in when the UI supports metrics with labels
+    # RW.Core.Push Metric    ${metric}    sub_name=with_labels    time=${results['time']}
 
 
 *** Keywords ***


### PR DESCRIPTION
This removes labels from push metric since the UI doesn't appear to support this yet. 