### PR TITLE
Datadog result overwrite

### DIFF
--- a/codebundles/datadog-metricquery/sli.robot
+++ b/codebundles/datadog-metricquery/sli.robot
@@ -44,13 +44,13 @@ Suite Initialization
     ...    pattern=\w*
     ...    example=series[0].pointlist[-1][1] this means get the newest data point from the first timeseries returned.
     ...    default=series[0].pointlist[-1][1]
-    RW.Core.Import User Variable    NO_RESULT_OVERWRITE
+    ${NO_RESULT_OVERWRITE}=    RW.Core.Import User Variable    NO_RESULT_OVERWRITE
     ...    type=string
     ...    description=Determine how to handle queries with no result data. Set to Yes to write a metric (specified below) or No to accept the null result. 
     ...    pattern=\w*
     ...    enum=[Yes,No]
     ...    default=No
-    RW.Core.Import User Variable    NO_RESULT_VALUE
+    ${NO_RESULT_VALUE}=    RW.Core.Import User Variable    NO_RESULT_VALUE
     ...    type=string
     ...    description=Set the metric value that should be stored when no data result is available.
     ...    pattern=\d*

--- a/codebundles/datadog-metricquery/sli.robot
+++ b/codebundles/datadog-metricquery/sli.robot
@@ -32,6 +32,12 @@ Suite Initialization
     ...    pattern=\w*
     ...    example=max:system.cpu.user{*}
     ...    default=max:system.cpu.user{*}
+    ${HISTORY_RANGE}=    RW.Core.Import User Variable    HISTORY_RANGE
+    ...    type=string
+    ...    pattern=((\d+?)d)?((\d+?)h)?((\d+?)m)?((\d+?)s)?
+    ...    description=How much history to fetch for the timeseries, in the format "1d7h10m", with possible unit values being 'd' representing days, 'h' representing hours, 'm' representing minutes, and 's' representing seconds.
+    ...    example=1h10m
+    ...    default=60s
     ${JSON_PATH}=    RW.Core.Import User Variable    JSON_PATH
     ...    type=string
     ...    description=A json path string that is used to extract data from the response.
@@ -43,6 +49,7 @@ Suite Initialization
     Set Suite Variable    ${DATADOG_SITE}    ${DATADOG_SITE}
     Set Suite Variable    ${METRIC_QUERY}    ${METRIC_QUERY}
     Set Suite Variable    ${JSON_PATH}    ${JSON_PATH}
+    Set Suite Variable    ${HISTORY_RANGE}    ${HISTORY_RANGE}
 
 *** Tasks ***
 Query Datadog Metrics
@@ -51,6 +58,7 @@ Query Datadog Metrics
     ...    app_key=${DATADOG_APP_KEY}
     ...    query_str=${METRIC_QUERY}
     ...    site=${DATADOG_SITE}
+    ...    within_time=${HISTORY_RANGE}
     ${metric}=    RW.Datadog.Handle Timeseries Data    json_path=${JSON_PATH}    rsp=${rsp}
     RW.Core.Push Metric    ${metric}
 

--- a/codebundles/datadog-metricquery/sli.robot
+++ b/codebundles/datadog-metricquery/sli.robot
@@ -44,12 +44,26 @@ Suite Initialization
     ...    pattern=\w*
     ...    example=series[0].pointlist[-1][1] this means get the newest data point from the first timeseries returned.
     ...    default=series[0].pointlist[-1][1]
+    RW.Core.Import User Variable    NO_RESULT_OVERWRITE
+    ...    type=string
+    ...    description=Determine how to handle queries with no result data. Set to Yes to write a metric (specified below) or No to accept the null result. 
+    ...    pattern=\w*
+    ...    enum=[Yes,No]
+    ...    default=No
+    RW.Core.Import User Variable    NO_RESULT_VALUE
+    ...    type=string
+    ...    description=Set the metric value that should be stored when no data result is available.
+    ...    pattern=\d*
+    ...    default=0
+    ...    example=0
     Set Suite Variable    ${DATADOG_API_KEY}    ${DATADOG_API_KEY}
     Set Suite Variable    ${DATADOG_APP_KEY}    ${DATADOG_APP_KEY}
     Set Suite Variable    ${DATADOG_SITE}    ${DATADOG_SITE}
     Set Suite Variable    ${METRIC_QUERY}    ${METRIC_QUERY}
     Set Suite Variable    ${JSON_PATH}    ${JSON_PATH}
     Set Suite Variable    ${HISTORY_RANGE}    ${HISTORY_RANGE}
+    Set Suite Variable    ${NO_RESULT_OVERWRITE}    ${NO_RESULT_OVERWRITE}
+    Set Suite Variable    ${NO_RESULT_VALUE}    ${NO_RESULT_VALUE}
 
 *** Tasks ***
 Query Datadog Metrics
@@ -59,6 +73,10 @@ Query Datadog Metrics
     ...    query_str=${METRIC_QUERY}
     ...    site=${DATADOG_SITE}
     ...    within_time=${HISTORY_RANGE}
-    ${metric}=    RW.Datadog.Handle Timeseries Data    json_path=${JSON_PATH}    rsp=${rsp}
+    ${metric}=    RW.Datadog.Handle Timeseries Data
+    ...    json_path=${JSON_PATH}
+    ...    rsp=${rsp}
+    ...    no_result_overwrite=${NO_RESULT_OVERWRITE}
+    ...    no_result_value=${NO_RESULT_VALUE}
     RW.Core.Push Metric    ${metric}
 

--- a/libraries/RW/Datadog/datadog.py
+++ b/libraries/RW/Datadog/datadog.py
@@ -47,8 +47,8 @@ class Datadog:
         if rsp[STATUS_KEY] != "ok":
             raise Exception(f"status of response not ok: {rsp}")
         extracted_data = utils.search_json(rsp, json_path)
-        if not extracted_data:
-            raise Exception(f"No data could be extracted with json path: {json_path} on rsp: {rsp}")
+        if extracted_data == None:
+            raise Exception(f"No data could be extracted with json path: {json_path} on rsp: {rsp} got return: {extracted_data}")
         return extracted_data
 
     def metric_query(

--- a/libraries/RW/Datadog/datadog.py
+++ b/libraries/RW/Datadog/datadog.py
@@ -29,7 +29,12 @@ class Datadog:
 
     ROBOT_LIBRARY_SCOPE = "GLOBAL"
 
-    def handle_timeseries_data(self, rsp: dict, json_path: str = "series[0].pointlist[-1][1]") -> any:
+    def handle_timeseries_data(
+        self, rsp: dict,
+        json_path: str = "series[0].pointlist[-1][1]",
+        no_result_overwrite="No",
+        no_result_value:float=0.0,
+    ) -> any:
         """
         Takes a datadog timeseries response and extracts data from it using a jmespath json path string.
         Verifies the status is OK.
@@ -44,11 +49,14 @@ class Datadog:
         Returns:
             any: varies depending on the extracted data.
         """
+        no_result_overwrite: bool = True if no_result_overwrite == "Yes" else False
         if rsp[STATUS_KEY] != "ok":
             raise Exception(f"status of response not ok: {rsp}")
         extracted_data = utils.search_json(rsp, json_path)
-        if extracted_data == None:
-            raise Exception(f"No data could be extracted with json path: {json_path} on rsp: {rsp} got return: {extracted_data}")
+        if extracted_data == None and no_result_overwrite:
+            extracted_data = no_result_value
+        elif extracted_data == None:
+            raise Exception(f"No data could be extracted with json path: {json_path} on rsp: {rsp} got return: {extracted_data} - consider using the no_result_overwrite option")
         return extracted_data
 
     def metric_query(


### PR DESCRIPTION
- tweak err handling in datadog
- Expose time range field to support larger aggregate queries
- add result overwrite as a backup for timeseries containing Nones