### PR TITLE
K8s Namespace Triage codebundle improvements

### DIFF
--- a/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
@@ -129,3 +129,14 @@ Object Condition Check
     ${history}=    RW.Utils.List To String    data_list=${history}
     RW.Core.Add Pre To Report    ${err_status_report}
     RW.Core.Add Pre To Report    Commands Used:\n${history}
+
+Namespace Get All
+    ${all_results}=    RW.K8s.Shell
+    ...    cmd=${binary_name} get all --context=${CONTEXT} -n ${NAMESPACE}
+    ...    target_service=${kubectl}
+    ...    kubeconfig=${kubeconfig}
+    ${history}=    RW.K8s.Pop Shell History
+    ${history}=    RW.Utils.List To String    data_list=${history}
+    RW.Core.Add Pre To Report    Informational Get All for Namespace: ${NAMESPACE}
+    RW.Core.Add Pre To Report    ${all_results}
+    RW.Core.Add Pre To Report    Commands Used:\n${history}

--- a/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
@@ -94,7 +94,7 @@ Fetch Unready Pods
     ...    kubeconfig=${kubeconfig}
     ${history}=    RW.K8s.Pop Shell History
     ${history}=    RW.Utils.List To String    data_list=${history}
-    IF    "${unreadypods_results}" == ""
+    IF    """${unreadypods_results}""" == ""
         ${unreadypods_results}=    Set Variable    No unready pods found
     END
     RW.Core.Add Pre To Report    Summary of unready pod restarts in namespace: ${NAMESPACE}

--- a/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
@@ -94,7 +94,10 @@ Fetch Unready Pods
     ...    kubeconfig=${kubeconfig}
     ${history}=    RW.K8s.Pop Shell History
     ${history}=    RW.Utils.List To String    data_list=${history}
-    RW.Core.Add Pre To Report    Summary of unhealthy pod restarts in namespace: ${NAMESPACE}
+    IF    "${unreadypods_results}" == ""
+        ${unreadypods_results}=    Set Variable    No unready pods found
+    END
+    RW.Core.Add Pre To Report    Summary of unready pod restarts in namespace: ${NAMESPACE}
     RW.Core.Add Pre To Report    ${unreadypods_results}
     RW.Core.Add Pre To Report    Commands Used:\n${history}
 
@@ -111,4 +114,18 @@ Triage Namespace
     ${history}=    RW.K8s.Pop Shell History
     ${history}=    RW.Utils.List To String    data_list=${history}
     RW.Core.Add Pre To Report    ${troubleshoot_report}
+    RW.Core.Add Pre To Report    Commands Used:\n${history}
+
+Object Condition Check
+    ${err_status_report}=    RW.K8s.Object Condition Check
+    ...    resource_kinds=${RESOURCE_KINDS}
+    ...    namespace=${NAMESPACE}
+    ...    context=${CONTEXT}
+    ...    kubeconfig=${kubeconfig}
+    ...    target_service=${kubectl}
+    ...    binary_name=${binary_name}
+    ...    failed_status_age=${EVENT_AGE}
+    ${history}=    RW.K8s.Pop Shell History
+    ${history}=    RW.Utils.List To String    data_list=${history}
+    RW.Core.Add Pre To Report    ${err_status_report}
     RW.Core.Add Pre To Report    Commands Used:\n${history}

--- a/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
+++ b/codebundles/k8s-kubectl-namespace-healthcheck/runbook.robot
@@ -35,8 +35,8 @@ Suite Initialization
     ...    type=string
     ...    description=Which Kubernetes kinds to inspect during troubleshooting as a CSV. Depending on kinds and your cluster workloads this can increase codebundle runtime.
     ...    pattern=\w*
-    ...    example=Deployment,DaemonSet,StatefulSet
-    ...    default=Deployment,DaemonSet,StatefulSet
+    ...    example=Deployment,DaemonSet,StatefulSet,Pod
+    ...    default=Deployment,DaemonSet,StatefulSet,Pod
     ${DISTRIBUTION}=    RW.Core.Import User Variable    DISTRIBUTION
     ...    type=string
     ...    description=Which distribution of Kubernetes to use for operations, such as: Kubernetes, OpenShift, etc.
@@ -89,7 +89,7 @@ Trace Namespace Errors
 *** Tasks ***
 Fetch Unready Pods
     ${unreadypods_results}=    RW.K8s.Shell
-    ...    cmd=${binary_name} get pods --context=${CONTEXT} -n ${NAMESPACE} --sort-by='status.containerStatuses[0].restartCount' --field-selector=status.phase!=Running,status.phase!=Succeeded
+    ...    cmd=${binary_name} get pods --context=${CONTEXT} -n ${NAMESPACE} --sort-by='status.containerStatuses[0].restartCount' --field-selector=status.phase!=Running
     ...    target_service=${kubectl}
     ...    kubeconfig=${kubeconfig}
     ${history}=    RW.K8s.Pop Shell History
@@ -124,7 +124,7 @@ Object Condition Check
     ...    kubeconfig=${kubeconfig}
     ...    target_service=${kubectl}
     ...    binary_name=${binary_name}
-    ...    failed_status_age=${EVENT_AGE}
+    ...    check_status_age=NO
     ${history}=    RW.K8s.Pop Shell History
     ${history}=    RW.Utils.List To String    data_list=${history}
     RW.Core.Add Pre To Report    ${err_status_report}

--- a/libraries/RW/K8s/namespace_tasks_mixin.py
+++ b/libraries/RW/K8s/namespace_tasks_mixin.py
@@ -695,7 +695,7 @@ Triage Namespace Summary: {status}
                 error_events_summary.append(ev["message"] + "\n")
         if error_events_summary:
             error_events_summary = "\t\t\t".join(
-                error_events_summary[0 : max(max_events_displayed, len(error_events_summary) - 1)]
+                error_events_summary[0 : max(max_events_displayed, len(error_events_summary)) - 1]
             )
         else:
             error_events_summary = "\t\tNo events captured for summary"

--- a/libraries/RW/K8s/namespace_tasks_mixin.py
+++ b/libraries/RW/K8s/namespace_tasks_mixin.py
@@ -690,11 +690,12 @@ Triage Namespace Summary: {status}
             kind = search_json(ev, "involvedObject.kind")
             if last_ts > start_time and ns == namespace and kind == "Pod":
                 name = search_json(ev, "involvedObject.name")
+                message = ev["message"]
                 filtered_events.append(ev)
                 events_involved_pods.append(name)
-                error_events_summary.append(ev["message"] + "\n")
+                error_events_summary.append(f"{kind}.{name}.{message}\n")
         if error_events_summary:
-            error_events_summary = "\t\t\t".join(
+            error_events_summary = "\t\t" + "\t\t".join(
                 error_events_summary[0 : max(max_events_displayed, len(error_events_summary)) - 1]
             )
         else:


### PR DESCRIPTION
- Adds a new object condition status summary task to the codebundle which pulls any names+condition messages with status == False, this can potentially surface minute issues and should be applicable to all objects
- Improved output formats for resources not present in the namespace, eg: no daemonsets results in a 0/0 for failed/checked in the output.
- The last 5 events will now be shown with their associated kind.name object (configurable at the keyword level but I haven't set this in the codebundle to avoid field bloat)
- Pods with restart counts within the age range will trigger a log fetch now, similar to pods with error events tied to them

Note: the log fetch is the last 20 lines and they're included only if they match the regex. These will be included in the report output so that users dont need to get access to the pod themselves - I have some perf. concerns but I'm curious about the value provided.

TODO: write more Kind parsers - on this note we should look at formalizing Parsers as a class before the code gets unruly