### PR TITLE
Add codebundles for gcloud cli

### DIFF
--- a/codebundles/gcp-gcloudcli-generic/README.md
+++ b/codebundles/gcp-gcloudcli-generic/README.md
@@ -1,0 +1,33 @@
+# Run Generic Gcloud Commands
+These two codebundle can be used to run arbitrary gcloud commands to perform automated tasks, capture output for a report, or return a metric for surfacing in an SLI.
+
+> Note: the `gcloud auth activate-service-account` call is done for you implicitly, so there's no need to add it into your command string.
+
+## SLI 
+A gcloud SLI for querying and extracting data from a generic gcloud call. Uses the hosted gcloud service, supports jq for parsing, and should prodice a single metric.
+
+## TaskSet
+Run a gcloud cli command and capture its output for use in a report, such as logs, restarting a VM, etc.
+
+## Use Cases
+### SLI: Get Number of Error Logs
+This example uses the SLI fetches the up to 20 warning/error log entries in the last 15 minutes as json, before counting the number of entries and providing it as a metric for your SLI. 
+
+```
+GCLOUD_COMMAND='gcloud logging read "severity>=WARNING" --freshness=15m --limit=20 --format=json | jq length'
+```
+
+### TaskSet: Fetch Last 5 Errors and Present in Report
+This example uses the TaskSet variant of the codebundle to fetch stdout and place it into a report on the platform for display to to users. In this case we're adding the last 5 warning/error log entries to a report (the entries will default to yaml)
+
+```
+GCLOUD_COMMAND='gcloud logging read "severity>=WARNING" --freshness=15m --limit=5'
+```
+
+## Requirements
+- The gcloud command string you'd like to run
+- A service account credentials json file to be used for authentication
+
+## TODO
+- [ ] Expand on examples
+- [ ] Determine if/what other gcloud plugins need to be installed for complex use cases

--- a/codebundles/gcp-gcloudcli-generic/runbook.robot
+++ b/codebundles/gcp-gcloudcli-generic/runbook.robot
@@ -1,0 +1,46 @@
+*** Settings ***
+Metadata          Author    Jonathan Funk
+Documentation     Run arbitrary gcloud commands and capture the stdout in a report.
+Force Tags        GCLOUD    CLI    JSON    DATA
+Suite Setup       Suite Initialization
+Library           RW.Core
+Library           RW.Utils
+Library           RW.GCP.GCloudCLI
+
+*** Keywords ***
+Suite Initialization
+    ${GCLOUD_COMMAND}=    RW.Core.Import User Variable    GCLOUD_COMMAND
+    ...    type=string
+    ...    description=gcloud command to run and return the stdout of.
+    ...    pattern=\w*
+    ...    default=gcloud logging read "severity>=WARNING" --freshness=15m --limit=5
+    ...    example=gcloud logging read "severity>=WARNING" --freshness=15m --limit=5
+    ${GCLOUD_SERVICE}=    RW.Core.Import Service    gcloud
+    ...    type=string
+    ...    description=The selected RunWhen Service to use for accessing services within a network.
+    ...    pattern=\w*
+    ...    example=gcloud-service.shared
+    ...    default=gcloud-service.shared
+    ${gcp_credentials_json}=    RW.Core.Import Secret    gcp_credentials_json
+    ...    type=string
+    ...    description=GCP service account json used to authenticate with GCP APIs.
+    ...    pattern=\w*
+    ...    example={"type": "service_account","project_id":"myproject-ID", ... super secret stuff ...}
+    ${PROJECT_ID}=    RW.Core.Import User Variable    PROJECT_ID
+    ...    type=string
+    ...    description=The GCP Project ID to scope the API to.
+    ...    pattern=\w*
+    ...    example=myproject-ID
+    Set Suite Variable    ${GCLOUD_COMMAND}    ${GCLOUD_COMMAND}
+    Set Suite Variable    ${GCLOUD_SERVICE}    ${GCLOUD_SERVICE}
+    Set Suite Variable    ${gcp_credentials_json}    ${gcp_credentials_json}
+    Set Suite Variable    ${PROJECT_ID}    ${PROJECT_ID}
+
+*** Tasks ***
+Run Gcloud CLI Command and Push metric
+    ${rsp}=    RW.GCP.GCloudCLI.Shell
+    ...    cmd=${GCLOUD_COMMAND}
+    ...    target_service=${GCLOUD_SERVICE}
+    ...    gcp_credentials_json=${gcp_credentials_json}
+    ...    project_id=${PROJECT_ID}
+    RW.Core.Add Pre To Report    ${rsp}

--- a/codebundles/gcp-gcloudcli-generic/sli.robot
+++ b/codebundles/gcp-gcloudcli-generic/sli.robot
@@ -1,0 +1,47 @@
+*** Settings ***
+Metadata          Author    Jonathan Funk
+Documentation     Run arbitrary gcloud commands and parse their output for arbitrary values such as json to be submitted as a metric.
+Force Tags        GCLOUD    CLI    JSON    DATA
+Suite Setup       Suite Initialization
+Library           RW.Core
+Library           RW.Utils
+Library           RW.GCP.GCloudCLI
+
+*** Keywords ***
+Suite Initialization
+    ${GCLOUD_COMMAND}=    RW.Core.Import User Variable    GCLOUD_COMMAND
+    ...    type=string
+    ...    description=gcloud command to run; should return a single metric. Can use jq for json parsing.  
+    ...    pattern=\w*
+    ...    default=gcloud logging read "severity>=WARNING" --freshness=15m --limit=20 --format=json | jq length
+    ...    example=gcloud logging read "severity>=WARNING" --freshness=15m --limit=20 --format=json | jq length
+    ${GCLOUD_SERVICE}=    RW.Core.Import Service    gcloud
+    ...    type=string
+    ...    description=The selected RunWhen Service to use for accessing services within a network.
+    ...    pattern=\w*
+    ...    example=gcloud-service.shared
+    ...    default=gcloud-service.shared
+    ${gcp_credentials_json}=    RW.Core.Import Secret    gcp_credentials_json
+    ...    type=string
+    ...    description=GCP service account json used to authenticate with GCP APIs.
+    ...    pattern=\w*
+    ...    example={"type": "service_account","project_id":"myproject-ID", ... super secret stuff ...}
+    ${PROJECT_ID}=    RW.Core.Import User Variable    PROJECT_ID
+    ...    type=string
+    ...    description=The GCP Project ID to scope the API to.
+    ...    pattern=\w*
+    ...    example=myproject-ID
+    Set Suite Variable    ${GCLOUD_COMMAND}    ${GCLOUD_COMMAND}
+    Set Suite Variable    ${GCLOUD_SERVICE}    ${GCLOUD_SERVICE}
+    Set Suite Variable    ${gcp_credentials_json}    ${gcp_credentials_json}
+    Set Suite Variable    ${PROJECT_ID}    ${PROJECT_ID}
+
+*** Tasks ***
+Run Gcloud CLI Command and Push metric
+    ${rsp}=    RW.GCP.GCloudCLI.Shell
+    ...    cmd=${GCLOUD_COMMAND}
+    ...    target_service=${GCLOUD_SERVICE}
+    ...    gcp_credentials_json=${gcp_credentials_json}
+    ...    project_id=${PROJECT_ID}
+    ${metric}=     Convert To Number    ${rsp}
+    RW.Core.Push Metric    ${metric}

--- a/libraries/RW/GCP/GCloudCLI.py
+++ b/libraries/RW/GCP/GCloudCLI.py
@@ -1,0 +1,46 @@
+import requests
+import logging
+import urllib
+import json
+import dateutil.parser
+from RW import platform, Utils
+
+logger = logging.getLogger(__name__)
+
+ROBOT_LIBRARY_SCOPE = "GLOBAL"
+
+
+def shell(
+    cmd: str,
+    target_service: platform.Service,
+    gcp_credentials_json: platform.Secret,
+    project_id: str = None,
+) -> any:
+    if not target_service:
+        raise ValueError("A runwhen service was not provided for the gcloud cli command")
+    if not gcp_credentials_json:
+        raise ValueError("A service account credentials json was not provided")
+    gcp_credentials_json_str = gcp_credentials_json.value
+    if Utils.is_json(gcp_credentials_json_str):
+        gcp_credentials_json_dict: dict = Utils.from_json(gcp_credentials_json_str)
+        if not project_id:
+            project_id = gcp_credentials_json_dict.get("project_id", None)
+    if not project_id:
+        raise ValueError("A project_id could not be found or was not provided")
+    # activate the service account in ssapi
+    cmd = f"gcloud auth activate-service-account --key-file=$GOOGLE_APPLICATION_CREDENTIALS && {cmd}"
+    logger.info(f"requesting command: {cmd}")
+    logger.info(f"selected project_id: {project_id}")
+    request_secrets: [platform.ShellServiceRequestSecret] = []
+    request_secrets.append(platform.ShellServiceRequestSecret(gcp_credentials_json, as_file=True))
+    env = {
+        "GOOGLE_APPLICATION_CREDENTIALS": f"./{gcp_credentials_json.key}",
+        "CLOUDSDK_CORE_PROJECT": f"{project_id}",
+    }
+    rsp = platform.execute_shell_command(cmd=cmd, service=target_service, request_secrets=request_secrets, env=env)
+    if (rsp.status != 200 or rsp.returncode > 0) and rsp.stderr != "":
+        raise ValueError(
+            f"The shell service responded with HTTP: {rsp.status} RC: {rsp.returncode} and response: {rsp}"
+        )
+    logger.info(f"shell stdout: {rsp.stdout}")
+    return rsp.stdout

--- a/libraries/RW/GCP/__init__.py
+++ b/libraries/RW/GCP/__init__.py
@@ -1,3 +1,4 @@
 from RW.GCP import OpsSuite
 from RW.GCP import Chat
 from RW.GCP import ServiceHealth
+from RW.GCP.GCloudCLI import *


### PR DESCRIPTION
- Adds 2 codebundles using the gcloud cli
- The SLI typically expects json output to be parsed by `jq` in order to get a resulting metric
- The taskset variant simply grabs stdout and adds to report