### PR TITLE
Cleans up gen rules that should have cloud_prodider matches for gcp ops suite

### DIFF
--- a/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/flux-reconciler-gcp-promql.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/flux-reconciler-gcp-promql.yaml
@@ -1,17 +1,24 @@
 kind: GenerationRules
 spec:
   generationRules:
-  - resourceTypes:
-    - namespace
-    matchRules:
-    - type: pattern
-      pattern: "flux-system"
-      properties: [name]
-      mode: substring
-    slxs:
-    - baseName: flux-reconcile
-      levelOfDetail: detailed
-      baseTemplateName: flux-reconciler-gcp-promql
-      outputItems:
-        - type: slx
-        - type: sli
+    - resourceTypes:
+        - namespace
+      matchRules:
+        - type: and
+          matches:
+            - type: pattern
+              pattern: "flux-system"
+              properties: [name]
+              mode: substring
+            - resourceType: variables
+              type: pattern
+              pattern: "gcp"
+              properties: [custom/cloud_provider]
+              mode: substring
+      slxs:
+      - baseName: flux-reconcile
+        levelOfDetail: detailed
+        baseTemplateName: flux-reconciler-gcp-promql
+        outputItems:
+          - type: slx
+          - type: sli

--- a/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/gke-cluster-health-generation-rule.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/gke-cluster-health-generation-rule.yaml
@@ -5,10 +5,17 @@ spec:
     - resourceTypes:
         - cluster
       matchRules:
-        - type: pattern
-          pattern: "."
-          properties: [name]
-          mode: substring
+        - type: and
+          matches:
+            - type: pattern
+              pattern: "."
+              properties: [name]
+              mode: substring
+            - resourceType: variables
+              type: pattern
+              pattern: "gcp"
+              properties: [custom/cloud_provider]
+              mode: substring
       slxs:
         - baseName: cpu
           qualifiers: [cluster]

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/flux-reconciler-gcp-promql-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/flux-reconciler-gcp-promql-slx.yaml
@@ -8,7 +8,7 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/flux-icon-color.svg
-  alias: Flux Reconciliations Health
+  alias: BOOOP Flux Reconciliations Health
   asMeasuredBy: Failing Reconciliations as reported by Flux through GMP
   configProvided:
   - name: OBJECT_NAME

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/flux-reconciler-gcp-promql-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/flux-reconciler-gcp-promql-slx.yaml
@@ -8,7 +8,7 @@ metadata:
     {% include "common-annotations.yaml" %}
 spec:
   imageURL: https://storage.googleapis.com/runwhen-nonprod-shared-images/icons/flux-icon-color.svg
-  alias: BOOOP Flux Reconciliations Health
+  alias: Flux Reconciliations Health
   asMeasuredBy: Failing Reconciliations as reported by Flux through GMP
   configProvided:
   - name: OBJECT_NAME


### PR DESCRIPTION
By no means a complete audit, but this fixes the condition we noticed yesterday when GKE cluster resources objects / SLXs were generated for non GCP users. 