### PR TITLE
template updates

### DIFF
--- a/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/flux-reconciler-gcp-promql.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/flux-reconciler-gcp-promql.yaml
@@ -19,6 +19,7 @@ spec:
       - baseName: flux-reconcile
         levelOfDetail: detailed
         baseTemplateName: flux-reconciler-gcp-promql
+        qualifiers: ["namespace", "cluster"]
         outputItems:
           - type: slx
           - type: sli

--- a/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/nginx-ingress-http-errors-gcp-promql.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/generation-rules/nginx-ingress-http-errors-gcp-promql.yaml
@@ -22,7 +22,7 @@ spec:
               mode: substring
       slxs:
         - baseName: ngx-ing-gmp
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: nginx-ingress-http-errors-gcp-promql
           levelOfDetail: detailed
           outputItems:

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/flux-reconciler-gcp-promql-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/flux-reconciler-gcp-promql-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/gke-cluster-cpu-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/gke-cluster-cpu-slx.yaml
@@ -16,3 +16,6 @@ spec:
   configProvided:
   - name: CLUSTER_NAME
     value: {{cluster.name}}
+  additionalContext:  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/gke-cluster-disk-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/gke-cluster-disk-slx.yaml
@@ -16,3 +16,6 @@ spec:
   configProvided:
   - name: CLUSTER_NAME
     value: {{cluster.name}}
+  additionalContext:  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/gke-cluster-mem-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/gke-cluster-mem-slx.yaml
@@ -16,3 +16,6 @@ spec:
   configProvided:
   - name: CLUSTER_NAME
     value: {{cluster.name}}
+  additionalContext:  
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/gcp-opssuite-promql/.runwhen/templates/nginx-ingress-http-errors-gcp-promql-slx.yaml
+++ b/codebundles/gcp-opssuite-promql/.runwhen/templates/nginx-ingress-http-errors-gcp-promql-slx.yaml
@@ -19,3 +19,5 @@ spec:
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
     labelMap: "{{match_resource.resource.metadata.labels}}" 
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/k8s-kubectl-get/.runwhen/generation-rules/k8s-certmanager-certificates-health.yaml
+++ b/codebundles/k8s-kubectl-get/.runwhen/generation-rules/k8s-certmanager-certificates-health.yaml
@@ -14,7 +14,7 @@ spec:
               mode: substring
       slxs:
         - baseName: cert-health
-          qualifiers: [resource]
+          qualifiers: ["resource", "namespace", "cluster"]
           baseTemplateName: k8s-certmanager-certificate-health
           levelOfDetail: basic
           outputItems:

--- a/codebundles/k8s-kubectl-get/.runwhen/templates/k8s-certmanager-certificate-health-slx.yaml
+++ b/codebundles/k8s-kubectl-get/.runwhen/templates/k8s-certmanager-certificate-health-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: All certificates should be in a Ready state 99.5%. 
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}"  
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"

--- a/codebundles/kong-ingress-health-gcp-promql/.runwhen/generation-rules/kong-ingress-health-gcp-promql.yaml
+++ b/codebundles/kong-ingress-health-gcp-promql/.runwhen/generation-rules/kong-ingress-health-gcp-promql.yaml
@@ -22,7 +22,7 @@ spec:
         mode: substring
     slxs:
     - baseName: kong-ing-health
-      qualifiers: [resource]
+      qualifiers: ["resource", "namespace", "cluster"]
       baseTemplateName: kong-ingress-health-gcp-promql
       levelOfDetail: detailed
       outputItems:

--- a/codebundles/kong-ingress-health-gcp-promql/.runwhen/templates/kong-ingress-health-gcp-promql-slx.yaml
+++ b/codebundles/kong-ingress-health-gcp-promql/.runwhen/templates/kong-ingress-health-gcp-promql-slx.yaml
@@ -18,4 +18,6 @@ spec:
   statement: Kong Ingress objects should available and performant 99.5% of the time.  
   additionalContext:  
     namespace: "{{match_resource.resource.metadata.namespace}}"
-    labelMap: "{{match_resource.resource.metadata.labels}}" 
+    labelMap: "{{match_resource.resource.metadata.labels}}"
+    cluster: "{{ cluster.name }}"
+    context: "{{ cluster.context }}"


### PR DESCRIPTION
Of note, this PR is required to support new grouping and multi-cluster strategies that will be released in runwhen-local 0.3.6