### PR TITLE
Libraries/RW/Prometheus - Non-Raw transforms only apply to result.values

### DIFF
--- a/libraries/RW/Prometheus/Prometheus.py
+++ b/libraries/RW/Prometheus/Prometheus.py
@@ -241,26 +241,24 @@ class Prometheus:
 
         if "value" in data["result"][metric_index]:
             metric_data = data["result"][metric_index]["value"]
+            if method == "Raw":
+                return metric_data[column_index]
         elif "values" in data["result"][metric_index]:
             metric_data = data["result"][metric_index]["values"]
-        if method == "Raw":
-            if "value" in data["result"][metric_index]:
-                return metric_data[column_index]
-            elif "values" in data["result"][metric_index]:
+            if method == "Raw":
                 return metric_data[first_data_point][column_index]
-
-        column = [float(row[column_index]) for row in metric_data]
-        if method == "Max":
-            return max(column)
-        elif method == "Average":
-            return sum(column) / len(column)
-        elif method == "Minimum":
-            return min(column)
-        elif method == "Sum":
-            return sum(column)
-        elif method == "First":
-            return column[0]
-        elif method == "Last":
-            return column[-1]
-        else:
-            raise ValueError(f"Invalid transform method {method} provided for aggregation on list")
+            column = [float(row[column_index]) for row in metric_data]
+            if method == "Max":
+                return max(column)
+            elif method == "Average":
+                return sum(column) / len(column)
+            elif method == "Minimum":
+                return min(column)
+            elif method == "Sum":
+                return sum(column)
+            elif method == "First":
+                return column[0]
+            elif method == "Last":
+                return column[-1]
+            else:
+                raise ValueError(f"Invalid transform method {method} provided for aggregation on list")


### PR DESCRIPTION
Objective: Run `RW.Prometheus` based codebundle against a Prometheus endpoint with default `transform`
Codebundle / Robot Script: [Infracloudio/ifc-rw-codecollection/.../runbook.robot](https://github.com/infracloudio/ifc-rw-codecollection/blob/f/codebundle-rds-mysql-conn/codebundles/rds-mysql-conn-count/runbook.robot)

Test Procedure:
- [Dockerfile](https://github.com/infracloudio/ifc-rw-codecollection/blob/f/codebundle-rds-mysql-conn/Dockerfile) 
- Run docker container as follow and we set RW_PATH_TO_ROBOT env
```
docker run --rm -d -p 3000:3000 --name rds-codecollection \
--network="host" \
-e ENV_PROMETHEUS_HOST="http://af87d61af0d814b8d8e99d37987b291d-483479890.us-west-2.elb.amazonaws.com/prometheus/api/v1" \
-e ENV_QUERY="aws_rds_database_connections_average{dimension_DBInstanceIdentifier=\"robotshopmysql\"} > 1" \
-e MYSQL_USER="admin" \
-e MYSQL_PASSWORD_ENV="<password>" \
-e MYSQL_HOST="robotshopmysql.c9m6m4s8zo0.us-west-2.rds.amazonaws.com" \
-e PROCESS_USER="shipping" \
-e RW_PATH_TO_ROBOT="/app/codecollection/codebundles/rds-mysql-conn-count/runbook.robot" \
runwhen:latest
```
Note: Here we are not supplying the type of transform with `-e TRANSFORM=Raw`

and, in the corresponding `sli.robot`, if we do not input `TRANSFORM` as an USER VARIABLE:
```
Querying Prometheus Instance And Pushing Aggregated Data
    Log      ${ENV_QUERY}
    ${rsp}=    RW.Prometheus.Query Instant
    ...    api_url=${ENV_PROMETHEUS_HOST}
    ...    query=${ENV_QUERY}
    ...    step=${STEP}
    ...    target_service=${CURL_SERVICE}
    ${data}=    Set Variable    ${rsp["data"]}
    ${metric}=    RW.Prometheus.Transform Data
    ...    data=${data}
    ...    *** method=${TRANSFORM} *** <------ commented out TRANSFORM
    ...    no_result_overwrite=${NO_RESULT_OVERWRITE}
    ...    no_result_value=${NO_RESULT_VALUE}
    RW.Core.Push Metric    ${metric}
```
then `RW.Prometheus.Transform Data` call defaults to `transform: Last`, as seen here:
```
    RW.Core.Import User Variable    TRANSFORM
    ...    type=string
    ...    enum=[Raw,Max,Average,Minimum,Sum,First,Last]
    ...    description=What transform method to apply to the column data. First and Last are position relative, so Last is the most recent value. Use Raw to skip transform. 
    ...    default=Last
    ...    example=Last
```

While this can be controlled by the developer of sli.robot, the current logic creates an edge case where all transforms that only shuld apply to `result.values:[][]`, can also be mistakenly called for `result.value:[]`, resulting in the following error:
```
14:17:58.613	TRACE	Arguments: [ data={'resultType': 'vector',
 'result': [{'metric': {'__name__': 'aws_rds_database_connections_average',
                        'account_id': '590183940259',
                        'container': 'yet-another-cloudwatch-exporter',
                        'dimension_DBInstanceIdentifier': 'robotshopmysql',
                        'endpoint': 'http',
                        'instance': '192.168.164.136:5000',
                        'job': 'yace',
                        'name': 'arn:aws:rds:us-west-2:590183940259:db:robotshopmysql',
                        'namespace': 'monitoring',
                        'pod': 'yace-8b8bd5598-j2xps',
                        'region': 'us-west-2',
                        'service': 'yace'},
             'value': [1706172466.004, '30.2']}]} | method='Last' | no_result_overwrite=True | no_result_value=0.0 ]	
14:17:58.614	FAIL	TypeError: 'float' object is not subscriptable
```
This is because all transforms other than `Raw` can only apply to 2D matrices of `[float][float]`, but here it gets applied to `[float]`.

This PR intends to fix this issue, by only allowing non-Raw transforms on `result.values[float][float]`
